### PR TITLE
Only perform homing if the CNC has moved from home.

### DIFF
--- a/libromi/include/oquam/Oquam.h
+++ b/libromi/include/oquam/Oquam.h
@@ -107,6 +107,8 @@ namespace romi {
 
                 bool enable_driver();
                 bool disable_driver();
+        private:
+            bool position_changed_;
         };
 }
 


### PR DESCRIPTION
Only perform a homing on power_up() call when one of the ICNC methods has been called on or initial startup.
