### PR TITLE
changed to int32 because of compiler error

### DIFF
--- a/libromi/src/hal/I2C.cpp
+++ b/libromi/src/hal/I2C.cpp
@@ -82,10 +82,10 @@ namespace romi {
 
         uint8_t I2C::compute_checksum()
         {
-                uint16_t sum = 0;
+                uint32_t sum = 0;
                 for (int i = 0; i < kCheckSumIndex; i++) 
                         sum += buffer_[i];
-                return (uint8_t) (sum & 0x00ff);
+                return (uint8_t) (sum & 0x000000ff);
         }
         
         void I2C::assure_checksum(uint8_t sum)

--- a/python/Readme.md
+++ b/python/Readme.md
@@ -8,3 +8,7 @@
 $ python3 -m pip install -e .
 ```
 
+To run the Romi hardware you will also need keras, tensorflow
+
+beacause it is challenging to get it for older raspberry versions i ended up with this one:
+https://github.com/PINTO0309/TensorflowLite-bin/releases

--- a/python/Readme.md
+++ b/python/Readme.md
@@ -10,5 +10,4 @@ $ python3 -m pip install -e .
 
 To run the Romi hardware you will also need keras, tensorflow
 
-beacause it is challenging to get it for older raspberry versions i ended up with this one:
-https://github.com/PINTO0309/TensorflowLite-bin/releases
+tensorflow is available for the newest raspbian 64 bit os


### PR DESCRIPTION
Compiling the `ci_dev` branch I got the following error:
```
/home/pi/romi-cidev/libromi/libromi/src/hal/I2C.cpp: In member function ‘uint8_t romi::I2C::compute_checksum()’:
/home/pi/romi-cidev/libromi/libromi/src/hal/I2C.cpp:87:29: error: conversion from ‘int’ to ‘uint16_t’ {aka ‘short unsigned int’} may change value [-Werror=conversion]
   87 |                         sum += buffer_[i];
      |                         ~~~~^~~~~~~~~~~~~
```
with the adjustments of this PR compiling was successfull. It should not have other side-effects because the sum is afterwards masked and converted to uint8